### PR TITLE
Update quiz to 4-beat pattern with rests

### DIFF
--- a/src/components/RhythmScore.jsx
+++ b/src/components/RhythmScore.jsx
@@ -18,12 +18,16 @@ const RhythmScore = ({ notes }) => {
 
         const vfNotes = notes.map(d => {
             let duration = '4';
+            let keys = ['f/5'];
             if (d === 'e') duration = '8';
             if (d === 'h') duration = '2';
+            if (d === 'er') { duration = '8r'; keys = ['b/4']; }
+            if (d === 'qr') { duration = '4r'; keys = ['b/4']; }
+            if (d === 'hr') { duration = '2r'; keys = ['b/4']; }
             return new StaveNote({
-                keys: ['f/5'],         // ← 1本線に乗る
+                keys,
                 duration,
-                stem_direction: 1      // ← 上向き
+                stem_direction: 1
             });
         });
 
@@ -31,7 +35,7 @@ const RhythmScore = ({ notes }) => {
         let beamGroup = [];
 
         for (const note of vfNotes) {
-            if (note.getDuration() === '8') {
+            if (note.getDuration() === '8' && !note.isRest()) {
                 beamGroup.push(note);
                 if (beamGroup.length === 2) {
                     beams.push(new Beam(beamGroup, false)); // ← 2個ずつで生成

--- a/src/data/questions.js
+++ b/src/data/questions.js
@@ -3,12 +3,12 @@
 export const QUESTIONS = [
   {
     id: 1,
-    correct: ['e', 'e', 'e', 'e'],
+    correct: ['q', 'e', 'e', 'qr', 'q'],
     choices: [
-      ['e', 'e', 'e', 'e'],
-      ['q', 'q', 'q', 'q'],
-      ['q', 'h'],
-      ['h', 'q', 'q'],
+      ['q', 'e', 'e', 'qr', 'q'],
+      ['q', 'qr', 'q', 'e', 'e'],
+      ['q', 'qr', 'qr', 'q'],
+      ['q', 'e', 'e', 'q', 'qr'],
     ]
   }
 ];

--- a/utils/playRhythm.js
+++ b/utils/playRhythm.js
@@ -1,7 +1,7 @@
 import * as Tone from 'tone';
 
 // ✅ テンポ（BPM）は1か所で管理
-export const BPM = 80;
+export const BPM = 100;
 
 /**
  * カウントイン（4拍）を安定したテンポで再生
@@ -49,14 +49,16 @@ export const playRhythm = async (notes) => {
   Tone.Transport.bpm.value = BPM;
 
   // ノートの長さを拍数で定義
-  const lengths = { e: 0.5, q: 1, h: 2 };
+  const lengths = { e: 0.5, q: 1, h: 2, er: 0.5, qr: 1, hr: 2 };
 
   let beat = 0;
   notes.forEach((note) => {
     const duration = lengths[note] ?? 1;
-    Tone.Transport.scheduleOnce((time) => {
-      synth.triggerAttackRelease('C5', '8n', time);
-    }, beat);
+    if (!String(note).endsWith('r')) {
+      Tone.Transport.scheduleOnce((time) => {
+        synth.triggerAttackRelease('C5', '8n', time);
+      }, beat);
+    }
     beat += duration;
   });
 


### PR DESCRIPTION
## Summary
- add support for rests in RhythmScore and playback
- update tempo to 100 BPM
- create new 4-beat quiz pattern with quarter notes, quarter rests and eighth notes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6860c08ab894832b98d1a738b195b76f