### PR TITLE
Add random quiz generation and trumpet sound

### DIFF
--- a/src/components/RhythmQuiz.jsx
+++ b/src/components/RhythmQuiz.jsx
@@ -1,13 +1,27 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import RhythmScore from './RhythmScore.jsx';
 import { playCountIn, playRhythm } from '../../utils/playRhythm.js';
-import { QUESTIONS } from '../data/questions.js';
+import { generateQuestion } from '../../utils/generateQuestions.js';
+
+const QUESTION_COUNT = 5;
 
 const RhythmQuiz = () => {
-  const [question] = useState(QUESTIONS[0]);
+  const [questions, setQuestions] = useState([]);
+  const [current, setCurrent] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(null);
   const [isAnswered, setIsAnswered] = useState(false);
+  const [score, setScore] = useState(0);
+
+  useEffect(() => {
+    const qs = [];
+    for (let i = 0; i < QUESTION_COUNT; i++) {
+      qs.push(generateQuestion(i + 1));
+    }
+    setQuestions(qs);
+  }, []);
+
+  const question = questions[current];
 
   const handleStart = async () => {
     setIsPlaying(true);
@@ -23,7 +37,16 @@ const RhythmQuiz = () => {
     setSelectedIndex(index);
     setIsAnswered(true);
     const isCorrect = question.choices[index].join() === question.correct.join();
+    if (isCorrect) setScore((s) => s + 1);
     alert(isCorrect ? '正解！' : 'ちがうよ！');
+  };
+
+  const handleNext = () => {
+    setSelectedIndex(null);
+    setIsAnswered(false);
+    if (current < QUESTION_COUNT - 1) {
+      setCurrent((c) => c + 1);
+    }
   };
 
   return (
@@ -45,6 +68,12 @@ const RhythmQuiz = () => {
             <RhythmScore notes={choice} />
           </div>
         ))}
+      </div>
+      <div style={{ marginTop: '20px' }}>
+        <p>{current + 1} / {QUESTION_COUNT} 問 - 正解 {score} 問</p>
+        {isAnswered && current < QUESTION_COUNT - 1 && (
+          <button onClick={handleNext}>次の問題</button>
+        )}
       </div>
     </div>
   );

--- a/src/components/RhythmScore.jsx
+++ b/src/components/RhythmScore.jsx
@@ -24,11 +24,15 @@ const RhythmScore = ({ notes }) => {
             if (d === 'er') { duration = '8r'; keys = ['b/4']; }
             if (d === 'qr') { duration = '4r'; keys = ['b/4']; }
             if (d === 'hr') { duration = '2r'; keys = ['b/4']; }
-            return new StaveNote({
+            const note = new StaveNote({
                 keys,
                 duration,
                 stem_direction: 1
             });
+            if (note.isRest()) {
+                note.setKeyLine(0, 0); // 休符をライン上に配置
+            }
+            return note;
         });
 
         const beams = [];

--- a/utils/generateQuestions.js
+++ b/utils/generateQuestions.js
@@ -1,0 +1,39 @@
+export const NOTE_OPTIONS = [
+  { value: 'q', beats: 1 },
+  { value: 'qr', beats: 1 },
+  { value: 'e', beats: 0.5 },
+  { value: 'er', beats: 0.5 },
+  { value: 'h', beats: 2 },
+  { value: 'hr', beats: 2 }
+];
+
+function randomElement(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+export function generateRhythm() {
+  const rhythm = [];
+  let beats = 0;
+  while (beats < 4) {
+    const options = NOTE_OPTIONS.filter(o => o.beats <= 4 - beats);
+    const pick = randomElement(options);
+    rhythm.push(pick.value);
+    beats += pick.beats;
+  }
+  return rhythm;
+}
+
+export function generateQuestion(id) {
+  const correct = generateRhythm();
+  const choices = [correct];
+  while (choices.length < 4) {
+    const cand = generateRhythm();
+    if (!choices.some(c => c.join() === cand.join())) choices.push(cand);
+  }
+  // shuffle choices
+  for (let i = choices.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [choices[i], choices[j]] = [choices[j], choices[i]];
+  }
+  return { id, correct, choices };
+}

--- a/utils/playRhythm.js
+++ b/utils/playRhythm.js
@@ -41,7 +41,17 @@ export const playRhythm = async (notes) => {
   }
 
   await Tone.start();
-  const synth = new Tone.Synth().toDestination();
+  const synth = new Tone.Synth({
+    oscillator: {
+      type: 'square'
+    },
+    envelope: {
+      attack: 0.01,
+      decay: 0.1,
+      sustain: 0.3,
+      release: 0.2
+    }
+  }).toDestination();
 
   // Transportの設定をカウントと合わせる
   Tone.Transport.stop();


### PR DESCRIPTION
## Summary
- place rest symbols on the staff line
- generate random rhythm questions and track progress
- play quiz rhythms with a trumpet-like sound

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6860cb344740832bb4b59420ea8a52bd