### PR TITLE
Fix rest position and use preset question list

### DIFF
--- a/src/components/RhythmQuiz.jsx
+++ b/src/components/RhythmQuiz.jsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import RhythmScore from './RhythmScore.jsx';
 import { playCountIn, playRhythm } from '../../utils/playRhythm.js';
-import { generateQuestion } from '../../utils/generateQuestions.js';
+import QUESTIONS from '../data/questions.js';
 
-const QUESTION_COUNT = 5;
+const QUESTION_COUNT = QUESTIONS.length;
 
 const RhythmQuiz = () => {
   const [questions, setQuestions] = useState([]);
@@ -14,11 +14,7 @@ const RhythmQuiz = () => {
   const [score, setScore] = useState(0);
 
   useEffect(() => {
-    const qs = [];
-    for (let i = 0; i < QUESTION_COUNT; i++) {
-      qs.push(generateQuestion(i + 1));
-    }
-    setQuestions(qs);
+    setQuestions(QUESTIONS);
   }, []);
 
   const question = questions[current];

--- a/src/components/RhythmScore.jsx
+++ b/src/components/RhythmScore.jsx
@@ -11,7 +11,10 @@ const RhythmScore = ({ notes }) => {
         renderer.resize(220, 140);
         const context = renderer.getContext();
 
-        const stave = new Stave(10, 40, 220);
+        const stave = new Stave(10, 40, 220, {
+            spaceAboveStaffLn: 0,
+            spaceBelowStaffLn: 0,
+        });
         stave.setNumLines(1); // ✅ ← これが正解！
         stave.setContext(context).draw();
 
@@ -21,9 +24,9 @@ const RhythmScore = ({ notes }) => {
             let keys = ['f/5'];
             if (d === 'e') duration = '8';
             if (d === 'h') duration = '2';
-            if (d === 'er') { duration = '8r'; keys = ['b/4']; }
-            if (d === 'qr') { duration = '4r'; keys = ['b/4']; }
-            if (d === 'hr') { duration = '2r'; keys = ['b/4']; }
+            if (d === 'er') { duration = '8r'; keys = ['r/4']; }
+            if (d === 'qr') { duration = '4r'; keys = ['r/4']; }
+            if (d === 'hr') { duration = '2r'; keys = ['r/4']; }
             const note = new StaveNote({
                 keys,
                 duration,

--- a/src/data/questions.js
+++ b/src/data/questions.js
@@ -10,6 +10,46 @@ export const QUESTIONS = [
       ['q', 'qr', 'qr', 'q'],
       ['q', 'e', 'e', 'q', 'qr'],
     ]
+  },
+  {
+    id: 2,
+    correct: ['qr', 'q', 'e', 'e', 'q'],
+    choices: [
+      ['qr', 'q', 'e', 'e', 'q'],
+      ['q', 'e', 'qr', 'q', 'e'],
+      ['q', 'q', 'qr', 'e', 'e'],
+      ['e', 'e', 'q', 'q', 'qr'],
+    ]
+  },
+  {
+    id: 3,
+    correct: ['h', 'q', 'qr'],
+    choices: [
+      ['h', 'q', 'qr'],
+      ['q', 'h', 'qr'],
+      ['qr', 'q', 'h'],
+      ['q', 'qr', 'h'],
+    ]
+  },
+  {
+    id: 4,
+    correct: ['q', 'qr', 'q', 'qr'],
+    choices: [
+      ['q', 'qr', 'q', 'qr'],
+      ['qr', 'q', 'qr', 'q'],
+      ['q', 'q', 'qr', 'qr'],
+      ['qr', 'qr', 'q', 'q'],
+    ]
+  },
+  {
+    id: 5,
+    correct: ['e', 'e', 'e', 'e', 'q', 'q'],
+    choices: [
+      ['e', 'e', 'e', 'e', 'q', 'q'],
+      ['q', 'e', 'e', 'e', 'q', 'e'],
+      ['e', 'q', 'e', 'e', 'e', 'q'],
+      ['q', 'q', 'e', 'e', 'e', 'e'],
+    ]
   }
 ];
 


### PR DESCRIPTION
## Summary
- ensure rests appear centered on the single line by adjusting stave options and rest note keys
- load quiz questions from a predefined file instead of generating them randomly
- expand the questions dataset with a few examples

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6860e23560b8832bb78087f873f00594