### PR TITLE
Randomize quiz choices

### DIFF
--- a/src/components/RhythmQuiz.jsx
+++ b/src/components/RhythmQuiz.jsx
@@ -14,7 +14,21 @@ const RhythmQuiz = () => {
   const [score, setScore] = useState(0);
 
   useEffect(() => {
-    setQuestions(QUESTIONS);
+    const shuffleArray = (arr) => {
+      const copy = [...arr];
+      for (let i = copy.length - 1; i > 0; i -= 1) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [copy[i], copy[j]] = [copy[j], copy[i]];
+      }
+      return copy;
+    };
+
+    const shuffled = QUESTIONS.map((q) => ({
+      ...q,
+      choices: shuffleArray(q.choices),
+    }));
+
+    setQuestions(shuffled);
   }, []);
 
   const question = questions[current];


### PR DESCRIPTION
## Summary
- shuffle the quiz choices so the correct answer isn't always first

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68613cd77508832bbdc8f19e65a13e4e